### PR TITLE
fix odd-lenght error on linux\mac

### DIFF
--- a/pgoapi/utilities.py
+++ b/pgoapi/utilities.py
@@ -180,4 +180,7 @@ def generateRequestHash(authticket, request):
 
 
 def d2h(f):
-    return hex(struct.unpack('<Q', struct.pack('<d', f))[0])[2:-1].decode("hex")
+    hexVal = hex(struct.unpack('<Q', struct.pack('<d', f))[0])[2:]
+    if len(hexVal) % 2 != 0:
+        hexVal = hexVal[:-1]
+    return hexVal.decode("hex")


### PR DESCRIPTION
Without this on some linux\mac machines it will not work due  to Odd-length error. I guess -1 there because on other machine there a space added at end that should be excluded, but it added not everywhere and on linux it just return a proper hex value. 
