### PR TITLE
Fix hex decoding in Python 3

### DIFF
--- a/pgoapi/utilities.py
+++ b/pgoapi/utilities.py
@@ -180,6 +180,6 @@ def generateRequestHash(authticket, request):
 
 
 def d2h(f):
-   hex = f2h(f)[2:].replace('L','')
-   hex = ("0" * (len(hex) % 2)) + hex
-   return  hex.decode("hex")
+    hex_str = f2h(f)[2:].replace('L','')
+    hex_str = ("0" * (len(hex_str) % 2)) + hex_str
+    return unhexlify(hex_str)


### PR DESCRIPTION
Use binascii's `unhexlify` (already imported) to decode the hex since using `decode` results in `AttributeError: 'str' object has no attribute 'decode'` in Python 3.