### PR TITLE
Add a sane API timeout.

### DIFF
--- a/pgoapi/rpc_api.py
+++ b/pgoapi/rpc_api.py
@@ -112,8 +112,8 @@ class RpcApi:
 
         request_proto_serialized = request_proto_plain.SerializeToString()
         try:
-            http_response = self._session.post(endpoint, data=request_proto_serialized)
-        except requests.exceptions.ConnectionError as e:
+            http_response = self._session.post(endpoint, data=request_proto_serialized, timeout=30)
+        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
             raise ServerBusyOrOfflineException(e)
 
         return http_response


### PR DESCRIPTION
Ensure a timeout is used otherwise api users may end up looking at the screen with no feedback.