### PR TITLE
Properly redirect RPC calls on status code 53

### DIFF
--- a/pgoapi/rpc_api.py
+++ b/pgoapi/rpc_api.py
@@ -364,6 +364,11 @@ class RpcApi:
         self.log.debug('Parsing sub RPC responses...')
         response_proto_dict['responses'] = {}
 
+        if response_proto_dict.get('status_code', 1) == 53:
+            exception = ServerApiEndpointRedirectException()
+            exception.set_redirected_endpoint(response_proto_dict['api_url'])
+            raise exception
+
         if 'returns' in response_proto_dict:
             del response_proto_dict['returns']
 


### PR DESCRIPTION
When the server returns status code 53, the API fails to properly parse the response, causing `IndexError`.

This raises a `ServerApiEndpointRedirectException` so that requests will use the new RPC url and be retried like they're supposed to.

Closes #47, replaces #59.