### PR TITLE
Error in auth.py check_access_token

### DIFF
--- a/pgoapi/auth.py
+++ b/pgoapi/auth.py
@@ -114,7 +114,7 @@ class Auth:
         Add few seconds to now so the token get refreshed 
         before it invalidates in the middle of the request
         """
-        now_s = get_time() + 120
+        now_s = get_time(False) + 120
 
         if self._access_token is not None:
             if self._access_token_expiry == 0:


### PR DESCRIPTION
check_access_token's `now_s` was initially getting the time in milliseconds, not seconds.

The comment for `now_s` also describes adding a few seconds, but 2 full minutes are added. This could be intentional.