### PR TITLE
Reduce default radius by half

### DIFF
--- a/pgoapi/utilities.py
+++ b/pgoapi/utilities.py
@@ -69,7 +69,7 @@ def get_pos_by_name(location_name):
     return (loc.latitude, loc.longitude, loc.altitude)
 
 EARTH_RADIUS = 6371 * 1000
-def get_cell_ids(lat, long, radius=1000):
+def get_cell_ids(lat, long, radius=500):
     # Max values allowed by server according to this comment:
     # https://github.com/AeonLucid/POGOProtos/issues/83#issuecomment-235612285
     if radius > 1500:


### PR DESCRIPTION
The default setting of 1000m was showing FAR more pokestops than what the game shows. By doing some trial and error in an area with a lot of pokestops, I found that using 500m resulted in an accurate number of pokestops when compared to what I see in-game. I guess it makes sense that the diameter is exactly 1 km. I'd recommend we update the default to be closer to the actual game.