### PR TITLE
Added future as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ protobuf>=3.0.0a3
 requests==2.10.0
 s2sphere==0.2.4
 gpsoauth==0.3.0
+future
 six
 xxhash
 requests[socks]


### PR DESCRIPTION
The `pokecli` script requires the `future` package, which might not be installed. It wasn't for me, anyway.