### PR TITLE
Add device info to requests

### DIFF
--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 class PGoApi:
 
-    def __init__(self, provider=None, oauth2_refresh_token=None, username=None, password=None, position_lat=None, position_lng=None, position_alt=None, proxy_config=None):
+    def __init__(self, provider=None, oauth2_refresh_token=None, username=None, password=None, position_lat=None, position_lng=None, position_alt=None, proxy_config=None, device_info=None):
         self.set_logger()
         self.log.info('%s v%s - %s', __title__, __version__, __copyright__)
 
@@ -67,6 +67,8 @@ class PGoApi:
 
         if proxy_config is not None:
             self._session.proxies = proxy_config
+
+        self.device_info = device_info
 
     def set_logger(self, logger=None):
         self.log = logger or logging.getLogger(__name__)
@@ -218,7 +220,7 @@ class PGoApiRequest:
             self.log.info('Not logged in')
             return NotLoggedInException()
 
-        request = RpcApi(self._auth_provider)
+        request = RpcApi(self._auth_provider, self.device_info)
         request._session = self.__parent__._session
 
         lib_path = self.__parent__.get_signature_lib()


### PR DESCRIPTION
Currently a blank device info is sent. This adds support for passing in your own device info.
Also persists `session_hash` to last between requests.

Example usage:
```
device_info = {}
device_info['device_id'] = "0123456789abcdef0123456789abcdef"
device_info['device_brand'] = "Apple"
device_info['device_model'] = "iPhone"
device_info['device_model_boot'] = "iPhone8,2"
device_info['hardware_manufacturer'] = "Apple"
device_info['hardware_model'] = "N66AP"
device_info['firmware_brand'] = "iPhone OS"
device_info['firmware_type'] = "9.3.3"

api = PGoApi(provider="google", username="wchill", password="password", position_lat=0.0, position_lng=0.0, position_alt=0.0, device_info=device_info)
```